### PR TITLE
add c++20 std::format and operator <=>; include test cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(semver LANGUAGES CXX VERSION 0.3.1)
+project(semver LANGUAGES CXX VERSION 0.3.3)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -16,13 +16,13 @@ include(GNUInstallDirs)
 ## --------------------------------------------------------------------
 ## Build
 ## --------------------------------------------------------------------
-message(PROJECT_NAME: ${PROJECT_NAME})
-message(CMAKE_HOST_SYSTEM: ${CMAKE_HOST_SYSTEM})
-message(CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE})
-message(CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER})
-message(CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID})
-message(CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION})
-message(CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS})
+message(STATUS "PROJECT_NAME: ${PROJECT_NAME}")
+message(VERBOSE "  CMAKE_HOST_SYSTEM: ${CMAKE_HOST_SYSTEM}")
+message(VERBOSE "  CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+message(VERBOSE "  CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+message(VERBOSE "  CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
+message(VERBOSE "  CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
+message(VERBOSE "  CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library (${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ provides the ability to **parse**, **compare**, and **increment** semantic versi
    FetchContent_Declare(
        cpp-semver
        GIT_REPOSITORY https://github.com/z4kn4fein/cpp-semver.git
-       GIT_TAG v0.3.2)
+       GIT_TAG v0.3.3)
    FetchContent_MakeAvailable(cpp-semver)
    ```
 

--- a/include/semver/semver.hpp
+++ b/include/semver/semver.hpp
@@ -25,10 +25,19 @@ SOFTWARE.
 #ifndef Z4KN4FEIN_SEMVER_H
 #define Z4KN4FEIN_SEMVER_H
 
+#include <ostream>
 #include <string>
 #include <regex>
 #include <utility>
 #include <vector>
+
+// conditionally include <format> and its dependency <string_view> for C++20
+#ifdef __cpp_lib_format
+#if __cpp_lib_format >= 201907L
+#include <format>
+#include <string_view>
+#endif
+#endif
 
 namespace semver
 {
@@ -313,6 +322,17 @@ namespace semver
             return compare(other) != 0;
         }
 
+        // conditionally provide three-way operator for C++20
+        #ifdef __cpp_impl_three_way_comparison
+        #if __cpp_impl_three_way_comparison >= 201907L
+
+        auto operator<=>(const version& other) const {
+            return compare(other);
+        }
+
+        #endif
+        #endif
+
         static version parse(const std::string& version_str, bool strict = true) {
             std::regex regex(strict ? version_pattern : loose_version_pattern);
             std::cmatch match;
@@ -371,5 +391,20 @@ namespace semver
         }
     }
 }
+
+// conditionally provide formatter for C++20
+#ifdef __cpp_lib_format
+#if __cpp_lib_format >= 201907L
+
+template <>
+struct std::formatter<semver::version> : std::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const semver::version& version, FormatContext& ctx) const {
+        return std::formatter<std::string_view>::format(version.str(), ctx);
+    }
+};
+
+#endif
+#endif
 
 #endif // Z4KN4FEIN_SEMVER_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,9 +12,17 @@ FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 
 file(GLOB test-sources CONFIGURE_DEPENDS *.cpp)
-add_executable(${PROJECT_NAME}-tests "${test-sources}")
-
-target_link_libraries(${PROJECT_NAME}-tests PRIVATE Catch2::Catch2WithMain ${PROJECT_NAME})
 
 include(Catch)
-catch_discover_tests(${PROJECT_NAME}-tests)
+
+# add c++17 tests
+add_executable(${PROJECT_NAME}-tests-17 "${test-sources}")
+set_target_properties(${PROJECT_NAME}-tests-17 PROPERTIES CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME}-tests-17 PRIVATE Catch2::Catch2WithMain ${PROJECT_NAME})
+catch_discover_tests(${PROJECT_NAME}-tests-17)
+
+# add c++17 tests
+add_executable(${PROJECT_NAME}-tests-20 "${test-sources}")
+set_target_properties(${PROJECT_NAME}-tests-20 PROPERTIES CXX_STANDARD 20)
+target_link_libraries(${PROJECT_NAME}-tests-20 PRIVATE Catch2::Catch2WithMain ${PROJECT_NAME})
+catch_discover_tests(${PROJECT_NAME}-tests-20)

--- a/test/compare.cpp
+++ b/test/compare.cpp
@@ -52,6 +52,7 @@ TEST_CASE("Test version compare, greater than, by prerelease", "[version][compar
     semver::version v = semver::version::parse("5.2.3-alpha.2");
     REQUIRE(v > semver::version::parse("5.2.3-alpha")); // by pre-release part count
     REQUIRE(v > semver::version::parse("5.2.3-alpha.1")); // by pre-release number comparison
+    REQUIRE(v < semver::version::parse("5.2.3-alpha.11")); // by pre-release number comparison
     REQUIRE(v > semver::version::parse("5.2.3-a")); // by pre-release alphabetical comparison
     REQUIRE(v >= semver::version::parse("5.2.3-alpha.2"));
 }
@@ -65,3 +66,16 @@ TEST_CASE("Test version equality", "[version][compare]") {
     REQUIRE(semver::version::parse("5.2.3-alpha.2+build.34") == semver::version::parse("5.2.3-alpha.2"));
     REQUIRE(semver::version::parse("5.2.3-alpha.2+build.34") == semver::version::parse("5.2.3-alpha.2+build.35"));
 }
+
+#ifdef __cpp_impl_three_way_comparison
+#if __cpp_impl_three_way_comparison >= 201907L
+
+    TEST_CASE("Test version 3-way compare", "[version][compare]") {
+        semver::version v = semver::version::parse("5.2.3");
+        REQUIRE((v <=> semver::version::parse("6.0.0")) < 0);
+        REQUIRE((v <=> semver::version::parse("4.0.0")) > 0);
+        REQUIRE((v <=> semver::version::parse("5.2.3")) == 0);
+    }
+
+#endif
+#endif

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -1,0 +1,24 @@
+#include <catch2/catch_all.hpp>
+#include <semver/semver.hpp>
+#include <sstream>
+
+TEST_CASE("Test version std::ostream <<", "[version]") {
+    semver::version v = semver::version::parse("5.2.3");
+    std::stringstream ss;
+    ss << v;
+    REQUIRE(ss.str() == "5.2.3");
+}
+
+#ifdef __cpp_lib_format
+#if __cpp_lib_format >= 201907L
+
+TEST_CASE("Test version std::format formatter", "[version]") {
+    REQUIRE(std::format("{}", semver::version::parse("5.2.3")) == "5.2.3");
+    REQUIRE(std::format("{}", semver::version::parse("5.2.3-alpha")) == "5.2.3-alpha");
+    REQUIRE(std::format("{}", semver::version::parse("5.2.3-1.2.3")) == "5.2.3-1.2.3");
+    REQUIRE(std::format("{}", semver::version::parse("5.2.3-alpha+build34")) == "5.2.3-alpha+build34");
+    REQUIRE(std::format("{}", semver::version::parse("5.2.3-1.2.3+build34")) == "5.2.3-1.2.3+build34");
+}
+
+#endif
+#endif


### PR DESCRIPTION
Hi. Liking your semver project.

* Add support for C++20 std::format and operator<=>
* add missing ostream include
* add test cases for above and operator<<
* bumped version to 0.3.3
